### PR TITLE
Bugfix/request get must return scalar value

### DIFF
--- a/Services/RequestEntityService.php
+++ b/Services/RequestEntityService.php
@@ -75,7 +75,7 @@ class RequestEntityService implements RequestEntityServiceInterface {
     $requestEntityOptions = $requestEntityClass::createRequestEntityOptions();
 
     if (null !== $rootElement = $requestEntityOptions->getRootElement()) {
-      $data = $request->request->get( $rootElement ) ?? [];
+      $data = $request->request->has($rootElement) ? $request->request->all($rootElement) : [];
     } else {
       $data = $request->request->all();
     }


### PR DESCRIPTION
In Symfony 6 `$request->request->get($key)`  is only for scalar values. `$request->request->all($key)` is for arrays.